### PR TITLE
fix: Add inotify-tools dependency

### DIFF
--- a/devenv.nix
+++ b/devenv.nix
@@ -7,6 +7,10 @@
   };
   languages.erlang.enable = true;
 
+  packages = with pkgs; [
+    inotify-tools
+  ];
+
   services.postgres = {
     enable = true;
     package = pkgs.postgresql_17;


### PR DESCRIPTION
By adding this dependency, mix can auto-reload phoenix server when filesystem changes are detected.